### PR TITLE
Feature/challenge mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,13 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+	// queryDsl
+	implementation 'com.querydsl:querydsl-core'
+	implementation 'com.querydsl:querydsl-jpa'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jpa"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
 	// mapper
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
@@ -64,6 +71,10 @@ dependencies {
 	// swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+}
+
+clean {
+	delete file('src/main/generated') // 인텔리제이 Annotation processor 생성물 생성위치
 }
 
 tasks.named('test') {

--- a/src/main/generated/dopamine/backend/challengemember/mapper/ChallengeMemberMapperImpl.java
+++ b/src/main/generated/dopamine/backend/challengemember/mapper/ChallengeMemberMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-12T01:09:10+0900",
+    date = "2023-09-13T01:13:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/generated/dopamine/backend/challengemember/mapper/ChallengeMemberMapperImpl.java
+++ b/src/main/generated/dopamine/backend/challengemember/mapper/ChallengeMemberMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-13T01:13:54+0900",
+    date = "2023-09-13T02:25:58+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/generated/dopamine/backend/level/mapper/LevelMapperImpl.java
+++ b/src/main/generated/dopamine/backend/level/mapper/LevelMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-12T16:10:02+0900",
+    date = "2023-09-13T01:13:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/generated/dopamine/backend/level/mapper/LevelMapperImpl.java
+++ b/src/main/generated/dopamine/backend/level/mapper/LevelMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-13T01:13:54+0900",
+    date = "2023-09-13T02:25:58+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/generated/dopamine/backend/member/mapper/MemberMapperImpl.java
+++ b/src/main/generated/dopamine/backend/member/mapper/MemberMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-12T16:10:02+0900",
+    date = "2023-09-13T01:13:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/generated/dopamine/backend/member/mapper/MemberMapperImpl.java
+++ b/src/main/generated/dopamine/backend/member/mapper/MemberMapperImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-09-13T01:13:54+0900",
+    date = "2023-09-13T02:25:58+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.6 (Azul Systems, Inc.)"
 )
 @Component

--- a/src/main/java/dopamine/backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/dopamine/backend/challenge/controller/ChallengeController.java
@@ -63,4 +63,9 @@ public class ChallengeController {
     public void editChallenge(@PathVariable Long challengeId, @RequestBody ChallengeEditDTO challengeEditDTO){
         challengeService.editChallenge(challengeId, challengeEditDTO);
     }
+
+    @GetMapping("/challenges/today-challenge/{userId}")
+    public void todayChallenge(@PathVariable Long userId){
+        challengeService.todayChallenge(userId);
+    }
 }

--- a/src/main/java/dopamine/backend/challenge/entity/Challenge.java
+++ b/src/main/java/dopamine/backend/challenge/entity/Challenge.java
@@ -31,7 +31,8 @@ public class Challenge extends BaseEntity {
 
     private String challengeGuide;
 
-    private Integer challengeLevel;
+    @Enumerated(EnumType.STRING)
+    private ChallengeLevel challengeLevel;
 
     @OneToMany(mappedBy = "challenge")
     private List<Feed> feeds = new ArrayList<>();
@@ -40,7 +41,7 @@ public class Challenge extends BaseEntity {
     private List<ChallengeMember> challengeMembers = new ArrayList<>();
 
     @Builder
-    public Challenge(String title, String subtitle, String image, String challengeGuide, Integer challengeLevel) {
+    public Challenge(String title, String subtitle, String image, String challengeGuide, ChallengeLevel challengeLevel) {
         this.title = title;
         this.subtitle = subtitle;
         this.image = image;

--- a/src/main/java/dopamine/backend/challenge/entity/ChallengeLevel.java
+++ b/src/main/java/dopamine/backend/challenge/entity/ChallengeLevel.java
@@ -1,0 +1,5 @@
+package dopamine.backend.challenge.entity;
+
+public enum ChallengeLevel {
+    HIGH, MID, LOW
+}

--- a/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepository.java
+++ b/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepository.java
@@ -1,0 +1,10 @@
+package dopamine.backend.challenge.repository;
+
+import dopamine.backend.challenge.entity.Challenge;
+
+import java.util.List;
+
+public interface ChallengeCustomRepository {
+
+    List<Challenge> getTodayChallenges(List<Challenge> existChallenges);
+}

--- a/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -1,0 +1,56 @@
+package dopamine.backend.challenge.repository;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dopamine.backend.challenge.entity.Challenge;
+import dopamine.backend.challenge.entity.ChallengeLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dopamine.backend.challenge.entity.QChallenge.challenge;
+
+@Repository
+@RequiredArgsConstructor
+public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Challenge> getTodayChallenges(List<Challenge> existChallenges) {
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if(existChallenges != null){
+            for(Challenge c : existChallenges){
+                predicates.add(challenge.challengeId.ne(c.getChallengeId()));
+            }
+        }
+
+        Predicate duplicatePredicate = ExpressionUtils.anyOf(predicates.toArray(new Predicate[0]));
+
+        Challenge challengeHigh = jpaQueryFactory.selectFrom(challenge)
+                .where(challenge.challengeLevel.eq(ChallengeLevel.HIGH),
+                        duplicatePredicate)
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .fetchFirst();
+
+        Challenge challengeMid = jpaQueryFactory.selectFrom(challenge)
+                .where(challenge.challengeLevel.eq(ChallengeLevel.MID),
+                        duplicatePredicate)
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .fetchFirst();
+
+        Challenge challengeLow = jpaQueryFactory.selectFrom(challenge)
+                .where(challenge.challengeLevel.eq(ChallengeLevel.LOW),
+                        duplicatePredicate)
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .fetchFirst();
+
+        return List.of(challengeHigh, challengeMid, challengeLow);
+    }
+}

--- a/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/dopamine/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
             }
         }
 
-        Predicate duplicatePredicate = ExpressionUtils.anyOf(predicates.toArray(new Predicate[0]));
+        Predicate duplicatePredicate = ExpressionUtils.allOf(predicates.toArray(new Predicate[0]));
 
         Challenge challengeHigh = jpaQueryFactory.selectFrom(challenge)
                 .where(challenge.challengeLevel.eq(ChallengeLevel.HIGH),

--- a/src/main/java/dopamine/backend/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/dopamine/backend/challenge/repository/ChallengeRepository.java
@@ -2,6 +2,11 @@ package dopamine.backend.challenge.repository;
 
 import dopamine.backend.challenge.entity.Challenge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+    @Query(nativeQuery = true, value = "SELECT * FROM challenge ORDER BY RAND() LIMIT 3")
+    List<Challenge> getRandomChallenges();
 }

--- a/src/main/java/dopamine/backend/challenge/request/ChallengeEditDTO.java
+++ b/src/main/java/dopamine/backend/challenge/request/ChallengeEditDTO.java
@@ -1,5 +1,6 @@
 package dopamine.backend.challenge.request;
 
+import dopamine.backend.challenge.entity.ChallengeLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +14,5 @@ public class ChallengeEditDTO {
     private String subtitle;
     private String image;
     private String challengeGuide;
-    private Integer challengeLevel;
+    private ChallengeLevel challengeLevel;
 }

--- a/src/main/java/dopamine/backend/challenge/request/ChallengeRequestDTO.java
+++ b/src/main/java/dopamine/backend/challenge/request/ChallengeRequestDTO.java
@@ -1,5 +1,6 @@
 package dopamine.backend.challenge.request;
 
+import dopamine.backend.challenge.entity.ChallengeLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +14,5 @@ public class ChallengeRequestDTO {
     private String subtitle;
     private String image;
     private String challengeGuide;
-    private Integer challengeLevel;
+    private ChallengeLevel challengeLevel;
 }

--- a/src/main/java/dopamine/backend/challenge/response/ChallengeResponseDTO.java
+++ b/src/main/java/dopamine/backend/challenge/response/ChallengeResponseDTO.java
@@ -1,5 +1,6 @@
 package dopamine.backend.challenge.response;
 
+import dopamine.backend.challenge.entity.ChallengeLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,5 +11,5 @@ public class ChallengeResponseDTO {
     private String subtitle;
     private String image;
     private String challengeGuide;
-    private Integer challengeLevel;
+    private ChallengeLevel challengeLevel;
 }

--- a/src/main/java/dopamine/backend/challenge/service/ChallengeService.java
+++ b/src/main/java/dopamine/backend/challenge/service/ChallengeService.java
@@ -6,9 +6,17 @@ import dopamine.backend.challenge.repository.ChallengeRepository;
 import dopamine.backend.challenge.request.ChallengeEditDTO;
 import dopamine.backend.challenge.request.ChallengeRequestDTO;
 import dopamine.backend.challenge.response.ChallengeResponseDTO;
+import dopamine.backend.challengemember.entity.ChallengeMember;
+import dopamine.backend.member.entity.Member;
+import dopamine.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +25,8 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeMapper challengeMapper;
+
+    private final MemberService memberService;
 
     private Challenge verifiedChallenge(Long challengeId) {
         return challengeRepository.findById(challengeId).orElseThrow(() -> new RuntimeException("존재하지 않는 챌린지입니다."));
@@ -54,5 +64,42 @@ public class ChallengeService {
         Challenge challenge = verifiedChallenge(challengeId);
 
         challenge.changeChallenge(challengeEditDTO);
+    }
+
+    public List<ChallengeResponseDTO> todayChallenge(Long userId) {
+
+        Member member = memberService.verifiedMember(userId);
+
+        // 기존에 챌린지 받은 적 없음
+        LocalDateTime existRefreshDate = member.getChallengeRefreshDate();
+        if(existRefreshDate == null){
+
+        }
+
+        // todo 오늘의 챌린지 3개 아니면 재발급?
+
+        // 오늘 날짜 조회
+        LocalDateTime today = LocalDateTime.now();
+
+        String todayInfo = today.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+        String existInfo = existRefreshDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+
+        List<ChallengeResponseDTO> challengeResponseList;
+        // member 오늘의 챌린지 갱신일 != 오늘 날짜 -> 새로운 챌린지 3개 매핑 (member 엔티티의 challengeMembers 갱신)
+        // 이때 필터는 기존 challenge x, 난이도별로 1개 씩 -> 상, 중, 하 대신 3개 뽑으려면 쿼리 3번
+        if(!todayInfo.equals(existInfo)){
+            List<Challenge> randomChallenges = challengeRepository.getRandomChallenges();
+            challengeResponseList = randomChallenges.stream().map(challengeMapper::challengeToChallengeResponseDTO).collect(Collectors.toList());
+        }
+
+        // member 오늘의 챌린지 갱신일 = 오늘 날짜 -> challengeMembers에 저장된 챌린지 리턴
+        else {
+            List<ChallengeMember> challengeMembers = member.getChallengeMembers();
+            challengeResponseList = challengeMembers.stream().map(challengeMember ->
+                    challengeMapper.challengeToChallengeResponseDTO(challengeMember.getChallenge())
+            ).collect(Collectors.toList());
+        }
+
+        return challengeResponseList;
     }
 }

--- a/src/main/java/dopamine/backend/challenge/service/ChallengeService.java
+++ b/src/main/java/dopamine/backend/challenge/service/ChallengeService.java
@@ -79,6 +79,8 @@ public class ChallengeService {
         if(existRefreshDate == null){
             List<Challenge> todayChallenges = challengeCustomRepository.getTodayChallenges(null);
             challengeResponseList = getChallengeResponseList(todayChallenges);
+
+            todayChallenges.stream().forEach((challenge) -> new ChallengeMember(member, challenge));
         }
 
         else {
@@ -93,12 +95,15 @@ public class ChallengeService {
             if(!todayInfo.equals(existInfo)){
                 List<Challenge> todayChallenges = challengeCustomRepository.getTodayChallenges(exitChallenge);
                 challengeResponseList = getChallengeResponseList(todayChallenges);
+
+                todayChallenges.stream().forEach((challenge) -> new ChallengeMember(member, challenge));
             }
             // 조회
             else {
                 challengeResponseList = getChallengeResponseList(exitChallenge);
             }
         }
+        member.setChallengeRefreshDate(LocalDateTime.now());
 
         return challengeResponseList;
     }

--- a/src/main/java/dopamine/backend/challengemember/entity/ChallengeMember.java
+++ b/src/main/java/dopamine/backend/challengemember/entity/ChallengeMember.java
@@ -1,10 +1,7 @@
 package dopamine.backend.challengemember.entity;
 
 import dopamine.backend.challenge.entity.Challenge;
-import dopamine.backend.challengemember.request.ChallengeMemberEditDto;
-import dopamine.backend.challengemember.request.ChallengeMemberRequestDto;
 import dopamine.backend.common.entity.BaseEntity;
-import dopamine.backend.level.entity.Level;
 import dopamine.backend.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,6 +39,11 @@ public class ChallengeMember extends BaseEntity {
     public ChallengeMember(Member member, Challenge challenge) {
         setMember(member);
         setChallenge(challenge);
+
+        if(!this.member.getChallengeMembers().contains(this))
+            this.member.getChallengeMembers().add(this);
+        if(!this.challenge.getChallengeMembers().contains(this))
+            this.challenge.getChallengeMembers().add(this);
     }
 
 

--- a/src/main/java/dopamine/backend/config/QueryDslConfig.java
+++ b/src/main/java/dopamine/backend/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package dopamine.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/dopamine/backend/config/SwaggerConfig.java
+++ b/src/main/java/dopamine/backend/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package dopamine.backend.swagger.config;
+package dopamine.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/dopamine/backend/member/entity/Member.java
+++ b/src/main/java/dopamine/backend/member/entity/Member.java
@@ -1,16 +1,17 @@
 package dopamine.backend.member.entity;
 
-import dopamine.backend.challenge.entity.Challenge;
 import dopamine.backend.challengemember.entity.ChallengeMember;
 import dopamine.backend.common.entity.BaseEntity;
 import dopamine.backend.level.entity.Level;
-import dopamine.backend.level.request.LevelEditDto;
-import dopamine.backend.level.service.LevelService;
 import dopamine.backend.member.request.MemberEditDto;
 import dopamine.backend.member.request.MemberRequestDto;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,8 @@ public class Member extends BaseEntity {
     private String nickname;
 
     private String refreshToken;
+
+    private LocalDateTime challengeRefreshDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "level_id")

--- a/src/main/java/dopamine/backend/member/entity/Member.java
+++ b/src/main/java/dopamine/backend/member/entity/Member.java
@@ -78,4 +78,8 @@ public class Member extends BaseEntity {
         this.level = Optional.ofNullable(level).orElse(this.level);
         this.level.getMembers().add(this);
     }
+
+    public void setChallengeRefreshDate(LocalDateTime localDateTime){
+        challengeRefreshDate = localDateTime;
+    }
 }

--- a/src/main/java/dopamine/backend/member/repository/MemberRepository.java
+++ b/src/main/java/dopamine/backend/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package dopamine.backend.member.repository;
 
 import dopamine.backend.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findMemberByKakaoId(String kakaoId);
-    Optional<Member> findMemberByNickname(String nickname);
+    Optional<Member> findMemberByKakaoId(@Param("kakaoId") String kakaoId);
+    Optional<Member> findMemberByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/dopamine/backend/querydsl/QueryDslConfig.java
+++ b/src/main/java/dopamine/backend/querydsl/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package dopamine.backend.config;
+package dopamine.backend.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/dopamine/backend/swagger/SwaggerConfig.java
+++ b/src/main/java/dopamine/backend/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package dopamine.backend.config;
+package dopamine.backend.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,14 +22,14 @@ spring:
 
   jpa:
     database: mysql
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
-        globally_quoted_identifiers: true
+        format_sql: false
+        show_sql: false
+        globally_quoted_identifiers: false
 
 logging:
   level:

--- a/src/test/java/dopamine/backend/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/dopamine/backend/challenge/service/ChallengeServiceTest.java
@@ -1,0 +1,148 @@
+package dopamine.backend.challenge.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dopamine.backend.challenge.entity.Challenge;
+import dopamine.backend.challenge.entity.ChallengeLevel;
+import dopamine.backend.challenge.repository.ChallengeRepository;
+import dopamine.backend.challenge.response.ChallengeResponseDTO;
+import dopamine.backend.level.entity.Level;
+import dopamine.backend.level.repository.LevelRepository;
+import dopamine.backend.level.request.LevelRequestDto;
+import dopamine.backend.member.entity.Member;
+import dopamine.backend.member.repository.MemberRepository;
+import dopamine.backend.member.request.MemberRequestDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ChallengeServiceTest {
+
+    @Autowired
+    private ChallengeService challengeService;
+    @Autowired
+    private ChallengeRepository challengeRepository;
+    @Autowired
+    private LevelRepository levelRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("오늘의 챌린지 테스트 - 신규 발급일때")
+    @Test
+    void todayChallengeNew() throws JsonProcessingException {
+
+        // given
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
+        LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").build();
+        Level level = Level.builder().levelRequestDto(levelRequestDto).build();
+        Member member = Member.builder().memberRequestDto(requestDto).level(level).build();
+
+        Challenge challenge1 = Challenge.builder().title("test1").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
+        Challenge challenge2 = Challenge.builder().title("test2").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.MID).build();
+        Challenge challenge3 = Challenge.builder().title("test3").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.LOW).build();
+
+        levelRepository.save(level);
+        memberRepository.save(member);
+        challengeRepository.saveAll(List.of(challenge1, challenge2, challenge3));
+
+        // when
+        Member findMember = memberRepository.findMemberByNickname("test").orElseThrow(() -> new RuntimeException("찾을 수 없음"));
+        Long memberId = findMember.getMemberId();
+
+        List<ChallengeResponseDTO> challengeResponseDTOS = challengeService.todayChallenge(memberId);
+
+        // then
+        Assertions.assertEquals(challengeResponseDTOS.size(), 3);
+        String json = objectMapper.writeValueAsString(challengeResponseDTOS);
+        System.out.println(json);
+    }
+
+    @DisplayName("오늘의 챌린지 테스트 - 어제 발급 받았을때")
+    @Test
+    void todayChallengeYesterday() throws JsonProcessingException {
+
+        // given
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
+        LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").build();
+        Level level = Level.builder().levelRequestDto(levelRequestDto).build();
+        Member member = Member.builder().memberRequestDto(requestDto).level(level).build();
+
+        Challenge challenge1 = Challenge.builder().title("test1").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
+        Challenge challenge2 = Challenge.builder().title("test2").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.MID).build();
+        Challenge challenge3 = Challenge.builder().title("test3").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.LOW).build();
+
+        levelRepository.save(level);
+        memberRepository.save(member);
+        challengeRepository.saveAll(List.of(challenge1, challenge2, challenge3));
+
+        Member findMember = memberRepository.findMemberByNickname("test").orElseThrow(() -> new RuntimeException("찾을 수 없음"));
+        Long memberId = findMember.getMemberId();
+
+        challengeService.todayChallenge(memberId);
+        member.setChallengeRefreshDate(LocalDateTime.now().minusDays(1));
+
+        Challenge challenge4 = Challenge.builder().title("test4").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
+        Challenge challenge5 = Challenge.builder().title("test5").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.MID).build();
+        Challenge challenge6 = Challenge.builder().title("test6").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.LOW).build();
+        challengeRepository.saveAll(List.of(challenge4, challenge5, challenge6));
+
+        // when
+        List<ChallengeResponseDTO> challengeResponseDTOS = challengeService.todayChallenge(memberId);
+
+        // then
+        Assertions.assertEquals(challengeResponseDTOS.size(), 3);
+        assertThat(challengeResponseDTOS.stream().map(ChallengeResponseDTO::getTitle)).contains("test4").contains("test5").contains("test6");
+        String json = objectMapper.writeValueAsString(challengeResponseDTOS);
+        System.out.println(json);
+    }
+
+    @DisplayName("오늘의 챌린지 테스트 - 이미 오늘 발급 받았을때")
+    @Test
+    void todayChallengeAlready() throws JsonProcessingException {
+
+        // given
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
+        LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").build();
+        Level level = Level.builder().levelRequestDto(levelRequestDto).build();
+        Member member = Member.builder().memberRequestDto(requestDto).level(level).build();
+
+        Challenge challenge1 = Challenge.builder().title("test1").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
+        Challenge challenge2 = Challenge.builder().title("test2").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.MID).build();
+        Challenge challenge3 = Challenge.builder().title("test3").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.LOW).build();
+
+        levelRepository.save(level);
+        memberRepository.save(member);
+        challengeRepository.saveAll(List.of(challenge1, challenge2, challenge3));
+
+        Member findMember = memberRepository.findMemberByNickname("test").orElseThrow(() -> new RuntimeException("찾을 수 없음"));
+        Long memberId = findMember.getMemberId();
+
+        challengeService.todayChallenge(memberId);
+
+        Challenge challenge4 = Challenge.builder().title("test4").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
+        Challenge challenge5 = Challenge.builder().title("test5").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.MID).build();
+        Challenge challenge6 = Challenge.builder().title("test6").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.LOW).build();
+        challengeRepository.saveAll(List.of(challenge4, challenge5, challenge6));
+
+        // when
+        List<ChallengeResponseDTO> challengeResponseDTOS = challengeService.todayChallenge(memberId);
+
+        // then
+        Assertions.assertEquals(challengeResponseDTOS.size(), 3);
+        assertThat(challengeResponseDTOS.stream().map(ChallengeResponseDTO::getTitle)).contains("test1").contains("test2").contains("test3");
+        String json = objectMapper.writeValueAsString(challengeResponseDTOS);
+        System.out.println(json);
+    }
+}


### PR DESCRIPTION
queryDsl 추가하고, config 파일 추가해주었습니다
이슈에 queryDsl 사용법 문서들 정리해두었습니다 #24 

오늘의 챌린지 난이도 상, 중, 하 별로 기존과 중복없이 가져오는 쿼리를 queryDsl 이용해서 짜보았습니다
아직 테스트를 안해봐서 빠른 시일 내 테스트 코드도 작성하겠습니다
마찬가지로 queryDsl에서 랜덤으로 하나 뽑는 법에 대한 문서 정리해두었습니다 #21 