### PR TITLE
[FEAT] : 챌린지, 인증글 S3 업로드 추가

### DIFF
--- a/src/main/java/dopamine/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/dopamine/backend/domain/challenge/controller/ChallengeController.java
@@ -4,9 +4,11 @@ import dopamine.backend.domain.challenge.request.ChallengeEditDTO;
 import dopamine.backend.domain.challenge.request.ChallengeRequestDTO;
 import dopamine.backend.domain.challenge.response.ChallengeResponseDTO;
 import dopamine.backend.domain.challenge.service.ChallengeService;
+import dopamine.backend.global.s3.service.ImageService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
@@ -17,12 +19,19 @@ public class ChallengeController {
 
     private final ChallengeService challengeService;
 
+    private final ImageService imageService;
+
     /**
      * 챌린지 생성
      * @param challengeRequestDTO
      */
     @PostMapping("/challenges")
-    public void createChallenge(@Valid @RequestBody ChallengeRequestDTO challengeRequestDTO){
+    public void createChallenge(@Valid @RequestPart(value = "request") ChallengeRequestDTO challengeRequestDTO,
+                                @RequestPart(value = "image", required = false) MultipartFile file){
+        if(file != null){
+            challengeRequestDTO.setImage(imageService.updateImage(file, "challenge", "image"));
+        }
+
         challengeService.createChallenge(challengeRequestDTO);
     }
 
@@ -60,10 +69,19 @@ public class ChallengeController {
      * @param challengeEditDTO
      */
     @PutMapping("/challenges/{challengeId}")
-    public void editChallenge(@PathVariable Long challengeId, @RequestBody ChallengeEditDTO challengeEditDTO){
+    public void editChallenge(@PathVariable Long challengeId, @RequestPart(value = "request") ChallengeEditDTO challengeEditDTO,
+                              @RequestPart(value = "image", required = false) MultipartFile file){
+        if(file != null){
+            challengeEditDTO.setImage(imageService.updateImage(file, "challenge", "image"));
+        }
+
         challengeService.editChallenge(challengeId, challengeEditDTO);
     }
 
+    /**
+     * 오늘의 챌린지
+     * @param userId
+     */
     @GetMapping("/challenges/today-challenge/{userId}")
     public void todayChallenge(@PathVariable Long userId){
         challengeService.todayChallenge(userId);

--- a/src/main/java/dopamine/backend/domain/challenge/entity/ChallengeLevel.java
+++ b/src/main/java/dopamine/backend/domain/challenge/entity/ChallengeLevel.java
@@ -1,5 +1,14 @@
 package dopamine.backend.domain.challenge.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum ChallengeLevel {
-    HIGH, MID, LOW
+    HIGH(30), MID(10), LOW(5);
+
+    private int exp;
+
+    private ChallengeLevel(Integer exp) {
+        this.exp = exp;
+    }
 }

--- a/src/main/java/dopamine/backend/domain/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/dopamine/backend/domain/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -21,11 +21,17 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    /**
+     * 오늘의 챌린지
+     * @param existChallenges
+     * @return
+     */
     @Override
     public List<Challenge> getTodayChallenges(List<Challenge> existChallenges) {
 
         List<Predicate> predicates = new ArrayList<>();
 
+        // 기존 챌린지와 일치하지 않도록 조건 추가
         if(existChallenges != null){
             for(Challenge c : existChallenges){
                 predicates.add(challenge.challengeId.ne(c.getChallengeId()));
@@ -34,18 +40,21 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
         Predicate duplicatePredicate = ExpressionUtils.allOf(predicates.toArray(new Predicate[0]));
 
+        // 기존 챌린지와 일치하지 않고, 난이도 상인 챌린지에서 랜덤으로 하나 가져오기
         Challenge challengeHigh = jpaQueryFactory.selectFrom(challenge)
                 .where(challenge.challengeLevel.eq(ChallengeLevel.HIGH),
                         duplicatePredicate)
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .fetchFirst();
 
+        // 기존 챌린지와 일치하지 않고, 난이도 중인 챌린지에서 랜덤으로 하나 가져오기
         Challenge challengeMid = jpaQueryFactory.selectFrom(challenge)
                 .where(challenge.challengeLevel.eq(ChallengeLevel.MID),
                         duplicatePredicate)
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .fetchFirst();
 
+        // 기존 챌린지와 일치하지 않고, 난이도 하인 챌린지에서 랜덤으로 하나 가져오기
         Challenge challengeLow = jpaQueryFactory.selectFrom(challenge)
                 .where(challenge.challengeLevel.eq(ChallengeLevel.LOW),
                         duplicatePredicate)

--- a/src/main/java/dopamine/backend/domain/challenge/request/ChallengeEditDTO.java
+++ b/src/main/java/dopamine/backend/domain/challenge/request/ChallengeEditDTO.java
@@ -15,4 +15,8 @@ public class ChallengeEditDTO {
     private String image;
     private String challengeGuide;
     private ChallengeLevel challengeLevel;
+
+    public void setImage(String image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/dopamine/backend/domain/challenge/request/ChallengeRequestDTO.java
+++ b/src/main/java/dopamine/backend/domain/challenge/request/ChallengeRequestDTO.java
@@ -15,4 +15,8 @@ public class ChallengeRequestDTO {
     private String image;
     private String challengeGuide;
     private ChallengeLevel challengeLevel;
+
+    public void setImage(String image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/dopamine/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/dopamine/backend/domain/challenge/service/ChallengeService.java
@@ -37,6 +37,10 @@ public class ChallengeService {
         return challengeRepository.findById(challengeId).orElseThrow(() -> new RuntimeException("존재하지 않는 챌린지입니다."));
     }
 
+    /**
+     * 챌린지 생성
+     * @param challengeRequestDTO
+     */
     public void createChallenge(ChallengeRequestDTO challengeRequestDTO) {
 
         Challenge challenge = challengeMapper.challengeRequestDtoToChallenge(challengeRequestDTO);
@@ -44,18 +48,31 @@ public class ChallengeService {
         challengeRepository.save(challenge);
     }
 
+    /**
+     * 챌린지 삭제
+     * @param challengeId
+     */
     public void deleteChallenge(Long challengeId) {
         Challenge challenge = verifiedChallenge(challengeId);
 
         challenge.changeDelYn(true);
     }
 
+    /**
+     * 챌린지 완전 삭제 (DB)
+     * @param challengeId
+     */
     public void deleteChallengeHard(Long challengeId) {
         Challenge challenge = verifiedChallenge(challengeId);
 
         challengeRepository.delete(challenge);
     }
 
+    /**
+     * 챌린지 조회
+     * @param challengeId
+     * @return
+     */
     @Transactional(readOnly = true)
     public ChallengeResponseDTO getChallenge(Long challengeId) {
         Challenge challenge = verifiedChallenge(challengeId);
@@ -65,12 +82,22 @@ public class ChallengeService {
         return challengeResponseDTO;
     }
 
+    /**
+     * 챌린지 수정
+     * @param challengeId
+     * @param challengeEditDTO
+     */
     public void editChallenge(Long challengeId, ChallengeEditDTO challengeEditDTO) {
         Challenge challenge = verifiedChallenge(challengeId);
 
         challenge.changeChallenge(challengeEditDTO);
     }
 
+    /**
+     * 오늘의 챌린지
+     * @param userId
+     * @return
+     */
     public List<ChallengeResponseDTO> todayChallenge(Long userId) {
 
         Member member = memberService.verifiedMember(userId);
@@ -94,7 +121,7 @@ public class ChallengeService {
             List<ChallengeMember> challengeMembers = member.getChallengeMembers();
             List<Challenge> exitChallenge = challengeMembers.stream().map(ChallengeMember::getChallenge).collect(Collectors.toList());
 
-            // 갱신
+            // 갱신일자가 오늘이 아닐 경우, 새로운 챌린지 발급
             if(!todayInfo.equals(existInfo)){
                 List<Challenge> todayChallenges = challengeCustomRepository.getTodayChallenges(exitChallenge);
 
@@ -104,6 +131,7 @@ public class ChallengeService {
                 }
                 challengeMemberRepository.deleteAllInBatch(challengeMembers);
 
+                // 오늘의 챌린지 생성
                 challengeResponseList = getChallengeResponseList(todayChallenges);
 
                 todayChallenges.stream().forEach((challenge) -> new ChallengeMember(member, challenge));

--- a/src/main/java/dopamine/backend/domain/feed/controller/FeedController.java
+++ b/src/main/java/dopamine/backend/domain/feed/controller/FeedController.java
@@ -4,9 +4,11 @@ import dopamine.backend.domain.feed.request.FeedEditDTO;
 import dopamine.backend.domain.feed.request.FeedRequestDTO;
 import dopamine.backend.domain.feed.response.FeedResponseDTO;
 import dopamine.backend.domain.feed.service.FeedService;
+import dopamine.backend.global.s3.service.ImageService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -16,6 +18,8 @@ import java.util.List;
 public class FeedController {
 
     private final FeedService feedService;
+
+    private final ImageService imageService;
 
     /**
      * 피드 조회
@@ -72,7 +76,28 @@ public class FeedController {
      * @param feedRequestDTO
      */
     @PostMapping("/feeds")
-    public void postFeed(@RequestBody FeedRequestDTO feedRequestDTO){
+    public void postFeed(@RequestPart(value = "request") FeedRequestDTO feedRequestDTO,
+                         @RequestPart(value = "images") List<MultipartFile> files){
+
+        int index = 0;
+
+        for(MultipartFile file : files){
+            if(file == null) continue;
+
+            if(index > 3) break;
+
+            if(index == 0)
+                feedRequestDTO.setImage1Url(imageService.updateImage(file, "challenge", "image1"));
+
+            else if(index == 1)
+                feedRequestDTO.setImage2Url(imageService.updateImage(file, "challenge", "image2"));
+
+            else if(index == 2)
+                feedRequestDTO.setImage3Url(imageService.updateImage(file, "challenge", "image3"));
+
+            index++;
+        }
+
         feedService.postFeed(feedRequestDTO);
     }
 
@@ -82,7 +107,28 @@ public class FeedController {
      * @param feedEditDTO
      */
     @PutMapping("/feeds/{feedId}")
-    public void editFeed(@PathVariable Long feedId, @RequestBody FeedEditDTO feedEditDTO) {
+    public void editFeed(@PathVariable Long feedId,
+                         @RequestPart(value = "request") FeedEditDTO feedEditDTO,
+                         @RequestPart(value = "images") List<MultipartFile> files) {
+        int index = 0;
+
+        for(MultipartFile file : files){
+            if(file == null) continue;
+
+            if(index > 3) break;
+
+            if(index == 0)
+                feedEditDTO.setImage1Url(imageService.updateImage(file, "challenge", "image1"));
+
+            else if(index == 1)
+                feedEditDTO.setImage2Url(imageService.updateImage(file, "challenge", "image2"));
+
+            else if(index == 2)
+                feedEditDTO.setImage3Url(imageService.updateImage(file, "challenge", "image3"));
+
+            index++;
+        }
+
         feedService.editFeed(feedId, feedEditDTO);
     }
 
@@ -92,7 +138,9 @@ public class FeedController {
      * @param value
      */
     @PatchMapping("/feeds/{feedId}/fulfill")
-    public void patchFeedFulfill(@PathVariable Long feedId, @RequestParam Boolean value){}
+    public void patchFeedFulfill(@PathVariable Long feedId, @RequestParam Boolean value){
+        feedService.patchFeedFulfill(feedId, value);
+    }
 
     /**
      * 피드 삭제

--- a/src/main/java/dopamine/backend/domain/feed/entity/Feed.java
+++ b/src/main/java/dopamine/backend/domain/feed/entity/Feed.java
@@ -34,7 +34,7 @@ public class Feed extends BaseEntity {
     private Integer likeCount = 0;
 
     @ColumnDefault("true")
-    private Boolean fulfillYn;
+    private Boolean fulfillYn = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -52,6 +52,10 @@ public class Feed extends BaseEntity {
         this.challenge = challenge;
         if(!this.challenge.getFeeds().contains(this))
             challenge.getFeeds().add(this);
+    }
+
+    public void setFulfillYn(Boolean fulfillYn) {
+        this.fulfillYn = fulfillYn;
     }
 
     public void addLikeCount(){

--- a/src/main/java/dopamine/backend/domain/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/dopamine/backend/domain/feed/repository/FeedCustomRepositoryImpl.java
@@ -21,43 +21,67 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 
     private final Integer PAGEOFFSET = 9;
 
+    /**
+     * 피드 리스트 조회 - 최신순
+     * @param page
+     * @return
+     */
     @Override
     public List<Feed> getFeedListOrderByDate(int page) {
         return jpaQueryFactory.selectFrom(feed)
+                .where(feed.fulfillYn.eq(true))
                 .orderBy(feed.createdDate.desc())
                 .limit(9)
                 .offset((long) (page - 1) * PAGEOFFSET)
                 .fetch();
     }
 
+    /**
+     * 피드 리스트 조회 - 좋아요순
+     * @param page
+     * @return
+     */
     @Override
     public List<Feed> getFeedListOrderByLikeCount(int page) {
         LocalDateTime dayOffset = LocalDateTime.now().minusDays(30L);
 
         return jpaQueryFactory.selectFrom(feed)
-                .where(feed.createdDate.after(dayOffset))
+                .where(feed.createdDate.after(dayOffset),
+                        feed.fulfillYn.eq(true))
                 .orderBy(feed.likeCount.desc())
                 .limit(9)
                 .offset((long) (page - 1) * PAGEOFFSET)
                 .fetch();
     }
 
+    /**
+     * 피드 리스트 조회 - 챌린지 기준, 좋아요 순
+     * @param challenge
+     * @return
+     */
     @Override
     public List<Feed> getFeedListByChallengeOrderByLikeCount(Challenge challenge) {
         LocalDateTime dayOffset = LocalDateTime.now().minusDays(30L);
 
         return jpaQueryFactory.selectFrom(feed)
                 .where(feed.createdDate.after(dayOffset),
-                        feed.challenge.eq(challenge))
+                        feed.challenge.eq(challenge),
+                        feed.fulfillYn.eq(true))
                 .orderBy(feed.likeCount.desc())
                 .limit(6)
                 .fetch();
     }
 
+    /**
+     * 피드 리스트 조회 - 멤버 기준, 최신순
+     * @param page, member
+     * @return
+     */
     @Override
     public List<Feed> getFeedListByMemberOrderByDate(int page, Member member) {
         return jpaQueryFactory.selectFrom(feed)
-                .where(feed.member.eq(member))
+                .where(feed.member.eq(member),
+                        feed.fulfillYn.eq(true))
                 .orderBy(feed.createdDate.desc())
                 .limit(9)
                 .offset((long) (page - 1) * PAGEOFFSET)

--- a/src/main/java/dopamine/backend/domain/feed/request/FeedEditDTO.java
+++ b/src/main/java/dopamine/backend/domain/feed/request/FeedEditDTO.java
@@ -10,5 +10,16 @@ public class FeedEditDTO {
     private String image1Url;
     private String image2Url;
     private String image3Url;
-    private Boolean openYn;
+
+    public void setImage1Url(String image1Url) {
+        this.image1Url = image1Url;
+    }
+
+    public void setImage2Url(String image2Url) {
+        this.image2Url = image2Url;
+    }
+
+    public void setImage3Url(String image3Url) {
+        this.image3Url = image3Url;
+    }
 }

--- a/src/main/java/dopamine/backend/domain/feed/request/FeedRequestDTO.java
+++ b/src/main/java/dopamine/backend/domain/feed/request/FeedRequestDTO.java
@@ -15,9 +15,19 @@ public class FeedRequestDTO {
 
     private String image3Url;
 
-    private Boolean openYn;
-
     private Long memberId;
 
     private Long challengeId;
+
+    public void setImage1Url(String image1Url) {
+        this.image1Url = image1Url;
+    }
+
+    public void setImage2Url(String image2Url) {
+        this.image2Url = image2Url;
+    }
+
+    public void setImage3Url(String image3Url) {
+        this.image3Url = image3Url;
+    }
 }

--- a/src/main/java/dopamine/backend/domain/feed/service/FeedService.java
+++ b/src/main/java/dopamine/backend/domain/feed/service/FeedService.java
@@ -1,18 +1,17 @@
 package dopamine.backend.domain.feed.service;
 
 import dopamine.backend.domain.challenge.entity.Challenge;
-import dopamine.backend.domain.challenge.entity.ChallengeLevel;
 import dopamine.backend.domain.challenge.mapper.ChallengeMapper;
 import dopamine.backend.domain.challenge.repository.ChallengeRepository;
 import dopamine.backend.domain.challenge.response.ChallengeResponseDTO;
 import dopamine.backend.domain.challenge.service.ChallengeService;
 import dopamine.backend.domain.feed.entity.Feed;
 import dopamine.backend.domain.feed.mapper.FeedMapper;
-import dopamine.backend.domain.feed.response.FeedResponseDTO;
 import dopamine.backend.domain.feed.repository.FeedCustomRepository;
 import dopamine.backend.domain.feed.repository.FeedRepository;
 import dopamine.backend.domain.feed.request.FeedEditDTO;
 import dopamine.backend.domain.feed.request.FeedRequestDTO;
+import dopamine.backend.domain.feed.response.FeedResponseDTO;
 import dopamine.backend.domain.member.entity.Member;
 import dopamine.backend.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +41,11 @@ public class FeedService {
         return feedRepository.findById(feedId).orElseThrow(() -> new RuntimeException("존재하지 않는 피드입니다."));
     }
 
+    /**
+     * 단건 피드 가져오기
+     * @param feedId
+     * @return
+     */
     @Transactional(readOnly = true)
     public FeedResponseDTO getFeed(Long feedId) {
         Feed feed = verifiedFeed(feedId);
@@ -54,6 +58,10 @@ public class FeedService {
         return feedMapper.feedToFeedResponseDto(feed, challengeResponseDTO);
     }
 
+    /**
+     * 피드 작성
+     * @param feedRequestDTO
+     */
     public void postFeed(FeedRequestDTO feedRequestDTO) {
         Challenge challenge = challengeRepository.findById(feedRequestDTO.getChallengeId()).orElseThrow(() -> new RuntimeException("존재하지 않는 챌린지입니다."));
 
@@ -63,49 +71,52 @@ public class FeedService {
         feed.setChallenge(challenge);
         feed.setMember(member);
 
-        // member의 exp추가 & level 반영
-        int exp = getExpByChallengeLevel(feed.getChallenge().getChallengeLevel());
+        // member의 exp추가 & level 반영 => ChallengeLevel Enum 값에 경험치 넣어주었습니다
+        int exp = feed.getChallenge().getChallengeLevel().getExp();
+
         memberService.plusMemberExp(member, exp);
 
         feedRepository.save(feed);
     }
 
+    /**
+     * 피드 수정
+     * @param feedId
+     * @param feedEditDTO
+     */
     public void editFeed(Long feedId, FeedEditDTO feedEditDTO) {
         Feed feed = verifiedFeed(feedId);
 
         feed.changeFeed(feedEditDTO);
     }
 
+    /**
+     * 피드 삭제 처리
+     * @param feedId
+     */
     public void deleteFeed(Long feedId) {
         Feed feed = verifiedFeed(feedId);
 
         feed.changeDelYn(true);
     }
 
+    /**
+     * 피드 완전 삭제 (DB)
+     * @param feedId
+     */
     public void deleteFeedHard(Long feedId) {
         Feed feed = verifiedFeed(feedId);
+
+        feed.deleteFromChallenge();
 
         feedRepository.delete(feed);
     }
 
     /**
-     * ChallengeLevel에 따른 exp 추출 => ChallengeLevel ENUM에 넣어도 되지 않을까요?
-     * HIGH : 20
-     * MID : 10
-     * LOW : 5
+     * 피드 리스트 변환 List<feed> -> List<feedResponseDTO>
+     * @param feedList
+     * @return
      */
-    private int getExpByChallengeLevel(ChallengeLevel challengeLevel) {
-        if (challengeLevel == ChallengeLevel.HIGH) {
-            return 30;
-        } else if (challengeLevel == challengeLevel.MID) {
-            return 10;
-        } else if (challengeLevel == challengeLevel.LOW) {
-            return 5;
-        } else {
-            return 0;
-        }
-    }
-
     private List<FeedResponseDTO> getFeedResponseDTOS(List<Feed> feedList) {
         List<FeedResponseDTO> feedResponseDTOList = feedList.stream().map(feed -> {
             ChallengeResponseDTO challengeResponseDTO = challengeMapper.challengeToChallengeResponseDTO(feed.getChallenge());
@@ -114,25 +125,57 @@ public class FeedService {
         return feedResponseDTOList;
     }
 
+    /**
+     * 피드 리스트 조회 - 최신순
+     * @param page
+     * @return
+     */
     public List<FeedResponseDTO> feedListOrderByDate(Integer page) {
         List<Feed> feedList = feedCustomRepository.getFeedListOrderByDate(page);
         return getFeedResponseDTOS(feedList);
     }
 
+    /**
+     * 피드 리스트 조회 - 좋아요 순
+     * @param page
+     * @return
+     */
     public List<FeedResponseDTO> feedListOrderByLikeCount(Integer page) {
         List<Feed> feedList = feedCustomRepository.getFeedListOrderByLikeCount(page);
         return getFeedResponseDTOS(feedList);
     }
 
+    /**
+     * 피드 리스트 조회 - 챌린지 기준
+     * @param challengeId
+     * @return
+     */
     public List<FeedResponseDTO> feedListByChallengeOrderByDate(Long challengeId) {
         Challenge challenge = challengeService.verifiedChallenge(challengeId);
         List<Feed> feedListByChallengeOrderByLikeCount = feedCustomRepository.getFeedListByChallengeOrderByLikeCount(challenge);
         return getFeedResponseDTOS(feedListByChallengeOrderByLikeCount);
     }
 
+    /**
+     * 피드 리스트 조회 - 유저 기준
+     * @param memberId
+     * @param page
+     * @return
+     */
     public List<FeedResponseDTO> feedListByMember(Long memberId, Integer page) {
         Member member = memberService.verifiedMember(memberId);
         List<Feed> feedListByMemberOrderByDate = feedCustomRepository.getFeedListByMemberOrderByDate(page, member);
         return getFeedResponseDTOS(feedListByMemberOrderByDate);
+    }
+
+    /**
+     * 인증 미달 여부 변경
+     * @param feedId
+     * @param value
+     */
+    public void patchFeedFulfill(Long feedId, Boolean value) {
+        Feed feed = verifiedFeed(feedId);
+
+        feed.setFulfillYn(value);
     }
 }

--- a/src/test/java/dopamine/backend/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/dopamine/backend/challenge/service/ChallengeServiceTest.java
@@ -16,6 +16,7 @@ import dopamine.backend.domain.member.repository.MemberRepository;
 import dopamine.backend.domain.member.request.MemberRequestDto;
 import dopamine.backend.domain.member.service.MemberService;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,14 +47,21 @@ class ChallengeServiceTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @BeforeEach
+    void clean(){
+        levelRepository.deleteAll();
+        memberRepository.deleteAll();
+        challengeRepository.deleteAll();
+    }
+
     @DisplayName("오늘의 챌린지 테스트 - 신규 발급일때")
     @Test
     void todayChallengeNew() throws JsonProcessingException {
 
         // given
-        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
         LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").exp(5).build();
         Level level = levelService.createLevel(levelRequestDto);
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").exp(5).build();
         Member member = memberService.createMember(requestDto);
 
         Challenge challenge1 = Challenge.builder().title("test1").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();
@@ -81,10 +89,9 @@ class ChallengeServiceTest {
     void todayChallengeYesterday() throws JsonProcessingException {
 
         // given
-        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
-
         LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").exp(5).build();
         Level level = levelService.createLevel(levelRequestDto);
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").exp(5).build();
         Member member = memberService.createMember(requestDto);
         levelRepository.save(level);
         memberRepository.save(member);
@@ -121,9 +128,9 @@ class ChallengeServiceTest {
     void todayChallengeAlready() throws JsonProcessingException {
 
         // given
-        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
         LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").exp(5).build();
         Level level = levelService.createLevel(levelRequestDto);
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").exp(5).build();
         Member member = memberService.createMember(requestDto);
 
         Challenge challenge1 = Challenge.builder().title("test1").challengeGuide(".").subtitle("1").image("i1").challengeLevel(ChallengeLevel.HIGH).build();

--- a/src/test/java/dopamine/backend/feed/service/FeedServiceTest.java
+++ b/src/test/java/dopamine/backend/feed/service/FeedServiceTest.java
@@ -14,6 +14,7 @@ import dopamine.backend.domain.member.entity.Member;
 import dopamine.backend.domain.member.repository.MemberRepository;
 import dopamine.backend.domain.member.request.MemberRequestDto;
 import dopamine.backend.domain.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,12 @@ class FeedServiceTest {
     @Autowired
     private FeedMapper feedMapper;
 
+    @BeforeEach
+    void clean(){
+        levelRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
     @Test
     @DisplayName("인증글 리스트 - 최신순")
     void feedlistbydate(){
@@ -79,9 +86,9 @@ class FeedServiceTest {
     void feedlistbylikecount(){
 
         // given
-        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
         LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").exp(5).build();
         Level level = levelService.createLevel(levelRequestDto);
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").exp(5).build();
         Member member = memberService.createMember(requestDto);
 
         levelRepository.save(level);
@@ -119,9 +126,9 @@ class FeedServiceTest {
     void feedlistbymember(){
 
         // given
-        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").build();
         LevelRequestDto levelRequestDto = LevelRequestDto.builder().name("testLev").exp(5).build();
         Level level = levelService.createLevel(levelRequestDto);
+        MemberRequestDto requestDto = MemberRequestDto.builder().nickname("test").exp(5).build();
         Member member = memberService.createMember(requestDto);
 
         levelRepository.save(level);


### PR DESCRIPTION
feed service에 추가하신 경험치 레벨에 따라 int값 반환하는 메소드를
ChallengeLevel enum값에서 경험치도 관리하는게 나을 것 같아 리팩토링하였습니다

파일 업로드도 알려주신 가이드대로 구현하였습니다
그런데 짜다보니 request DTO랑 실제 들어와야할 데이터 값이랑 차이가 있어서 
현재 RequestDTO 하나를
1. client -> server 용 DTO
2. controller -> service 용 DTO (이미지 정보 추가)
로 분리해야 할까 생각 중입니다 어떻게 생각하시나요?